### PR TITLE
Generate aggregated cluster roles for Gateway API CRD copies in `x-openshift.microgateway.airlock.com`

### DIFF
--- a/tests/golden/olm/airlock-microgateway/airlock-microgateway/00_prerequisites/00_airlock_xopenshift/backendtlspolicies.x-openshift.microgateway.airlock.com.yaml
+++ b/tests/golden/olm/airlock-microgateway/airlock-microgateway/00_prerequisites/00_airlock_xopenshift/backendtlspolicies.x-openshift.microgateway.airlock.com.yaml
@@ -646,3 +646,68 @@ status:
     plural: ''
   conditions: null
   storedVersions: null
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: backendtlspolicies.x-openshift.microgateway.airlock.com-crdview
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - backendtlspolicies.x-openshift.microgateway.airlock.com
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: backendtlspolicies.x-openshift.microgateway.airlock.com-view
+rules:
+  - apiGroups:
+      - x-openshift.microgateway.airlock.com
+    resources:
+      - backendtlspolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: backendtlspolicies.x-openshift.microgateway.airlock.com-edit
+rules:
+  - apiGroups:
+      - x-openshift.microgateway.airlock.com
+    resources:
+      - backendtlspolicies
+    verbs:
+      - create
+      - delete
+      - update
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+  name: backendtlspolicies.x-openshift.microgateway.airlock.com-admin
+rules:
+  - apiGroups:
+      - x-openshift.microgateway.airlock.com
+    resources:
+      - backendtlspolicies
+    verbs:
+      - '*'


### PR DESCRIPTION
The implementation currently assumes that all copied CRDs should have standard access (i.e. read for `view`, read-write for `edit` and `admin`).

Follow-up for #9 

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
