### PR TITLE
Extend HTTPRoute Certificate Manager `ManagedResource` to support custom `Certificate` configs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -26,6 +26,7 @@ parameters:
       gateway_default_cluster_issuer_annotation: airlock-microgateway.appuio.io/httproute-default-cluster-issuer
       cluster_issuer_annotation: airlock-microgateway.appuio.io/cluster-issuer
       issuer_annotation: airlock-microgateway.appuio.io/issuer
+      base_certificate_spec: {}
 
     gateway_api:
       # Installs upstream Kubernetes Gateway API if true

--- a/component/espejote-templates/httproute-certificate-manager.jsonnet
+++ b/component/espejote-templates/httproute-certificate-manager.jsonnet
@@ -7,6 +7,7 @@ local clusterIssuerAnnotation = config.clusterIssuerAnnotation;
 local issuerAnnotation = config.issuerAnnotation;
 local tlsSecretNameAnnotation = config.tlsSecretNameAnnotation;
 local gatewayDefaultClusterIssuerAnnotation = config.gatewayDefaultClusterIssuerAnnotation;
+local baseCertificateSpec = config.baseCertificateSpec;
 
 local gateways = esp.context().gateways;
 
@@ -137,7 +138,7 @@ local certForHTTRoute(route) =
             },
           ],
         },
-        spec: {
+        spec: baseCertificateSpec {
           dnsNames: route.spec.hostnames,
           issuerRef: issuer,
           secretName: secretName,

--- a/component/httproute-certificate-manager.libsonnet
+++ b/component/httproute-certificate-manager.libsonnet
@@ -58,6 +58,7 @@ local jsonnetlib =
           issuerAnnotation: params.httproute_certificate_manager.issuer_annotation,
           gatewayDefaultClusterIssuerAnnotation: params.httproute_certificate_manager.gateway_default_cluster_issuer_annotation,
           createCertificateAnnotation: params.httproute_certificate_manager.create_certificate_annotation,
+          baseCertificateSpec: params.httproute_certificate_manager.base_certificate_spec,
         }),
       },
     },

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -153,6 +153,21 @@ default:: `airlock-microgateway.appuio.io/issuer`
 
 The annotation to use on `HTTPRoute` resources to specify the issuer for certificates.
 
+=== `base_certificate_spec`
+
+[horizontal]
+type:: object
+default:: `{}`
+
+The value of this parameter is used as the base value for field `spec` of `Certificate` resources created by the HTTPRoute Certificate Manager.
+See the https://cert-manager.io/docs/usage/certificate/#creating-certificate-resources[cert-manager documentation] for supported fields.
+
+[NOTE]
+====
+The HTTPRoute Certificate Manager unconditionally sets fields `spec.dnsNames`, `spec.issuerRef`, and `spec.secretName` based on `HTTPRoute` or `Gateway` annotations.
+Additionally the HTTPRoute Certificate Manager unconditionally sets field `spec.usages` to `['digital signature', 'key encipherment']`.
+====
+
 == `gateway_api`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -22,3 +22,6 @@ parameters:
 
     httproute_certificate_manager:
       enabled: true
+      base_certificate_spec:
+        privateKey:
+          size: 4096

--- a/tests/golden/defaults/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/80_httproute_certificate_manager_managedresource.yaml
+++ b/tests/golden/defaults/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/80_httproute_certificate_manager_managedresource.yaml
@@ -9,6 +9,11 @@ spec:
   data:
     config.json: |-
       {
+          "baseCertificateSpec": {
+              "privateKey": {
+                  "size": 4096
+              }
+          },
           "clusterIssuerAnnotation": "airlock-microgateway.appuio.io/cluster-issuer",
           "createCertificateAnnotation": "airlock-microgateway.appuio.io/create-certificate",
           "gatewayDefaultClusterIssuerAnnotation": "airlock-microgateway.appuio.io/httproute-default-cluster-issuer",
@@ -53,6 +58,7 @@ spec:
     local issuerAnnotation = config.issuerAnnotation;
     local tlsSecretNameAnnotation = config.tlsSecretNameAnnotation;
     local gatewayDefaultClusterIssuerAnnotation = config.gatewayDefaultClusterIssuerAnnotation;
+    local baseCertificateSpec = config.baseCertificateSpec;
 
     local gateways = esp.context().gateways;
 
@@ -183,7 +189,7 @@ spec:
                 },
               ],
             },
-            spec: {
+            spec: baseCertificateSpec {
               dnsNames: route.spec.hostnames,
               issuerRef: issuer,
               secretName: secretName,


### PR DESCRIPTION
This PR introduces component parameter `httproute_certificate_manager.base_certificate_spec` which allows cluster-operators to customize the default configuration (`.spec`) for `Certificate` resources created by the HTTPRoute Certificate Manager Espejote `ManagedResource`.

Some fields in the certificates are unconditionally set by the `ManagedResource`, see the documentation diff for details.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
