### PR TITLE
Support one certificate per hostname in Gateway Listener Manager/HTTPRoute Certificate Manager

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,11 +18,14 @@ parameters:
       enabled: false
       create_listener_annotation: airlock-microgateway.appuio.io/create-gateway-https-listener
       tls_secret_name_annotation: airlock-microgateway.appuio.io/tls-secret-name
+      certificate_per_hostname_annotation: airlock-microgateway.appuio.io/certificate-per-hostname
+
 
     httproute_certificate_manager:
       enabled: false
       create_certificate_annotation: airlock-microgateway.appuio.io/create-certificate
       tls_secret_name_annotation: ${airlock_microgateway_operator:gateway_listener_manager:tls_secret_name_annotation}
+      certificate_per_hostname_annotation: ${airlock_microgateway_operator:gateway_listener_manager:certificate_per_hostname_annotation}
       gateway_default_cluster_issuer_annotation: airlock-microgateway.appuio.io/httproute-default-cluster-issuer
       cluster_issuer_annotation: airlock-microgateway.appuio.io/cluster-issuer
       issuer_annotation: airlock-microgateway.appuio.io/issuer

--- a/component/espejote-templates/gateway-listener-manager.jsonnet
+++ b/component/espejote-templates/gateway-listener-manager.jsonnet
@@ -3,6 +3,7 @@ local config = import 'gateway-listener-manager/config.json';
 
 local createListenerAnnotation = config.createListenerAnnotation;
 local tlsSecretNameAnnotation = config.tlsSecretNameAnnotation;
+local certificatePerHostnameAnnotation = config.certificatePerHostnameAnnotation;
 
 local finalizer = 'airlock-microgateway.appuio.io/gateway-listener-manager';
 local parentRefTrackAnnotation = 'internal.gateway-listener-manager.airlock-microgateway.appuio.io/track-parent-refs';
@@ -24,6 +25,11 @@ local wantsHttpsListener(obj) =
   &&
   secretName(obj) != ''
 ;
+
+local wantsCertificatePerHostname(obj) =
+  std.get(
+    std.get(obj.metadata, 'annotations', {}), certificatePerHostnameAnnotation, 'false'
+  ) == 'true';
 
 local routeHostnameRefs(route) =
   std.mapWithIndex(
@@ -103,7 +109,11 @@ local ensureListenerAndFinalizer(obj) =
                   {
                     group: '',
                     kind: 'Secret',
-                    name: secretName(obj),
+                    name:
+                      if wantsCertificatePerHostname(obj) then
+                        '%s-%d' % [ secretName(obj), h.pos ]
+                      else
+                        secretName(obj),
                     namespace: obj.metadata.namespace,
                   },
                 ],

--- a/component/espejote-templates/httproute-certificate-manager.jsonnet
+++ b/component/espejote-templates/httproute-certificate-manager.jsonnet
@@ -3,6 +3,7 @@ local esp = import 'espejote.libsonnet';
 local config = import 'httproute-certificate-manager/config.json';
 
 local createCertificateAnnotation = config.createCertificateAnnotation;
+local certificatePerHostnameAnnotation = config.certificatePerHostnameAnnotation;
 local clusterIssuerAnnotation = config.clusterIssuerAnnotation;
 local issuerAnnotation = config.issuerAnnotation;
 local tlsSecretNameAnnotation = config.tlsSecretNameAnnotation;
@@ -114,6 +115,33 @@ local issuerForRoute(route) =
     ,
   );
 
+local makeCertificate(route, issuer, secretName, h=null) = {
+  apiVersion: 'cert-manager.io/v1',
+  kind: 'Certificate',
+  metadata: {
+    name: route.metadata.name + '-cert' + if h != null then '-%d' % h.pos else '',
+    namespace: route.metadata.namespace,
+    ownerReferences: [
+      {
+        apiVersion: route.apiVersion,
+        kind: route.kind,
+        controller: true,
+        name: route.metadata.name,
+        uid: route.metadata.uid,
+      },
+    ],
+  },
+  spec: baseCertificateSpec {
+    dnsNames: if h != null then [ h.hostname ] else route.spec.hostnames,
+    issuerRef: issuer,
+    secretName: if h != null then '%s-%d' % [ secretName, h.pos ] else secretName,
+    usages: [
+      'digital signature',
+      'key encipherment',
+    ],
+  },
+};
+
 local certForHTTRoute(route) =
   local secretName = getAnnotation(route, tlsSecretNameAnnotation);
   if getAnnotation(route, createCertificateAnnotation) != 'true' || secretName == '' then
@@ -122,32 +150,19 @@ local certForHTTRoute(route) =
     err('no hostnames found for HTTPRoute %(namespace)s/%(name)s' % route.metadata)
   else
     issuerForRoute(route).match(
-      ok=function(issuer) ok({
-        apiVersion: 'cert-manager.io/v1',
-        kind: 'Certificate',
-        metadata: {
-          name: route.metadata.name + '-cert',
-          namespace: route.metadata.namespace,
-          ownerReferences: [
-            {
-              apiVersion: route.apiVersion,
-              kind: route.kind,
-              controller: true,
-              name: route.metadata.name,
-              uid: route.metadata.uid,
-            },
-          ],
-        },
-        spec: baseCertificateSpec {
-          dnsNames: route.spec.hostnames,
-          issuerRef: issuer,
-          secretName: secretName,
-          usages: [
-            'digital signature',
-            'key encipherment',
-          ],
-        },
-      }),
+      ok=function(issuer) ok(
+        if getAnnotation(route, certificatePerHostnameAnnotation) == 'true' then [
+          makeCertificate(route, issuer, secretName, h)
+          for h in std.mapWithIndex(
+            function(index, hostname) {
+              hostname: hostname,
+              pos: index,
+            }, route.spec.hostnames
+          )
+        ] else [
+          makeCertificate(route, issuer, secretName),
+        ]
+      ),
     )
 ;
 

--- a/component/gateway-listener-manager.libsonnet
+++ b/component/gateway-listener-manager.libsonnet
@@ -60,6 +60,7 @@ local jsonnetlib =
         'config.json': std.manifestJson({
           createListenerAnnotation: params.gateway_listener_manager.create_listener_annotation,
           tlsSecretNameAnnotation: params.gateway_listener_manager.tls_secret_name_annotation,
+          certificatePerHostnameAnnotation: params.gateway_listener_manager.certificate_per_hostname_annotation,
         }),
       },
     },

--- a/component/httproute-certificate-manager.libsonnet
+++ b/component/httproute-certificate-manager.libsonnet
@@ -54,6 +54,7 @@ local jsonnetlib =
       data: {
         'config.json': std.manifestJson({
           tlsSecretNameAnnotation: params.httproute_certificate_manager.tls_secret_name_annotation,
+          certificatePerHostnameAnnotation: params.httproute_certificate_manager.certificate_per_hostname_annotation,
           clusterIssuerAnnotation: params.httproute_certificate_manager.cluster_issuer_annotation,
           issuerAnnotation: params.httproute_certificate_manager.issuer_annotation,
           gatewayDefaultClusterIssuerAnnotation: params.httproute_certificate_manager.gateway_default_cluster_issuer_annotation,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -93,6 +93,16 @@ default:: `airlock-microgateway.appuio.io/tls-secret-name`
 
 The annotation to use on `HTTPRoute` resources to specify the name of the TLS secret to use for HTTPS listeners.
 
+== `certificate_per_hostname_annotation`
+
+[horizontal]
+type:: string
+default:: `airlock-microgateway.appuio.io/certificate-per-hostname`
+
+The annotation to use on `HTTPRoute` resources to indicate that the HTTPS listeners for each host name in `spec.hostnames` should be configured with certificates stored in secrets named `<SECRET NAME>-<N>`, where N is the zero-based index of each listener's hostname in `spec.hostnames`.
+The value `<SECRET NAME>` is read from the annotation key configured in parameter `gateway_listener_manager.tls_secret_name_annotation`.
+Must be set to `ANNOTATION: "true"` in the resource annotations.
+
 == `httproute_certificate_manager`
 
 [horizontal]
@@ -118,6 +128,33 @@ type:: string
 default:: `${airlock_microgateway:gateway_listener_manager:tls_secret_name_annotation}`
 
 The annotation to use on `HTTPRoute` resources to specify the name of the TLS secret to create the certificate in.
+
+== `certificate_per_hostname_annotation`
+
+[horizontal]
+type:: string
+default:: `${airlock_microgateway_operator:gateway_listener_manager:certificate_per_hostname_annotation}`
+
+The annotation to use on `HTTPRoute` resources to indicate that the HTTPRoute Certificate Manager should create a separate `Certificate` resource for each hostname in `spec.hostnames`.
+Must be set to `ANNOTATION: "true"` in the resource annotations.
+
+If enabled, the HTTPRoute Certificate Manager will create `Certificate` resources named `<ROUTE NAME>-cert-<N>`, where N is the zero-based index of the certificate's hostname in the HTTPRoute's `spec.hostnames`.
+In this mode, each `Certificate` resource is configured with a secret name of the form `<SECRET NAME>-<N>` where N matches the `<N>` in the `Certificate` resource name, and the value `<SECRET NAME>` is read from the annotation key configured in parameter `httproute_certificate_manager.tls_secret_name_annotation`.
+
+[IMPORTANT]
+====
+The feature ensures that there are distinct `Certificate` resource names depending on whether per-hostname certificate creation is enabled or disabled.
+The HTTPRoute Certificate Manager doesn't delete the `Certificate` resource(s) associated with the previous mode when a HTTPRoute is annotated to enable or disable per-hostname certificates.
+
+We strongly recommend that users manually delete any `Certificate`resources associated with the previous mode when changing a HTTPRoute's configuration to enable or disable per-hostname certificates.
+Otherwise, cert-manager will continue to renew those certificates on their regular schedules.
+====
+
+[TIP]
+====
+The per-hostname certificate creation should be able to handle arbitrary changes to `spec.hostnames` of an existing HTTPRoute gracefully.
+However, such changes may cause certificates to be re-issued.
+====
 
 === `create_certificate_annotation`
 

--- a/tests/golden/defaults/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/80_gateway_listener_manager_managedresource.yaml
+++ b/tests/golden/defaults/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/80_gateway_listener_manager_managedresource.yaml
@@ -9,6 +9,7 @@ spec:
   data:
     config.json: |-
       {
+          "certificatePerHostnameAnnotation": "airlock-microgateway.appuio.io/certificate-per-hostname",
           "createListenerAnnotation": "airlock-microgateway.appuio.io/create-gateway-https-listener",
           "tlsSecretNameAnnotation": "airlock-microgateway.appuio.io/tls-secret-name"
       }
@@ -40,6 +41,7 @@ spec:
 
     local createListenerAnnotation = config.createListenerAnnotation;
     local tlsSecretNameAnnotation = config.tlsSecretNameAnnotation;
+    local certificatePerHostnameAnnotation = config.certificatePerHostnameAnnotation;
 
     local finalizer = 'airlock-microgateway.appuio.io/gateway-listener-manager';
     local parentRefTrackAnnotation = 'internal.gateway-listener-manager.airlock-microgateway.appuio.io/track-parent-refs';
@@ -61,6 +63,11 @@ spec:
       &&
       secretName(obj) != ''
     ;
+
+    local wantsCertificatePerHostname(obj) =
+      std.get(
+        std.get(obj.metadata, 'annotations', {}), certificatePerHostnameAnnotation, 'false'
+      ) == 'true';
 
     local routeHostnameRefs(route) =
       std.mapWithIndex(
@@ -140,7 +147,11 @@ spec:
                       {
                         group: '',
                         kind: 'Secret',
-                        name: secretName(obj),
+                        name:
+                          if wantsCertificatePerHostname(obj) then
+                            '%s-%d' % [ secretName(obj), h.pos ]
+                          else
+                            secretName(obj),
                         namespace: obj.metadata.namespace,
                       },
                     ],

--- a/tests/golden/defaults/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/80_httproute_certificate_manager_managedresource.yaml
+++ b/tests/golden/defaults/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/80_httproute_certificate_manager_managedresource.yaml
@@ -14,6 +14,7 @@ spec:
                   "size": 4096
               }
           },
+          "certificatePerHostnameAnnotation": "airlock-microgateway.appuio.io/certificate-per-hostname",
           "clusterIssuerAnnotation": "airlock-microgateway.appuio.io/cluster-issuer",
           "createCertificateAnnotation": "airlock-microgateway.appuio.io/create-certificate",
           "gatewayDefaultClusterIssuerAnnotation": "airlock-microgateway.appuio.io/httproute-default-cluster-issuer",
@@ -54,6 +55,7 @@ spec:
     local config = import 'httproute-certificate-manager/config.json';
 
     local createCertificateAnnotation = config.createCertificateAnnotation;
+    local certificatePerHostnameAnnotation = config.certificatePerHostnameAnnotation;
     local clusterIssuerAnnotation = config.clusterIssuerAnnotation;
     local issuerAnnotation = config.issuerAnnotation;
     local tlsSecretNameAnnotation = config.tlsSecretNameAnnotation;
@@ -165,6 +167,33 @@ spec:
         ,
       );
 
+    local makeCertificate(route, issuer, secretName, h=null) = {
+      apiVersion: 'cert-manager.io/v1',
+      kind: 'Certificate',
+      metadata: {
+        name: route.metadata.name + '-cert' + if h != null then '-%d' % h.pos else '',
+        namespace: route.metadata.namespace,
+        ownerReferences: [
+          {
+            apiVersion: route.apiVersion,
+            kind: route.kind,
+            controller: true,
+            name: route.metadata.name,
+            uid: route.metadata.uid,
+          },
+        ],
+      },
+      spec: baseCertificateSpec {
+        dnsNames: if h != null then [ h.hostname ] else route.spec.hostnames,
+        issuerRef: issuer,
+        secretName: if h != null then '%s-%d' % [ secretName, h.pos ] else secretName,
+        usages: [
+          'digital signature',
+          'key encipherment',
+        ],
+      },
+    };
+
     local certForHTTRoute(route) =
       local secretName = getAnnotation(route, tlsSecretNameAnnotation);
       if getAnnotation(route, createCertificateAnnotation) != 'true' || secretName == '' then
@@ -173,32 +202,19 @@ spec:
         err('no hostnames found for HTTPRoute %(namespace)s/%(name)s' % route.metadata)
       else
         issuerForRoute(route).match(
-          ok=function(issuer) ok({
-            apiVersion: 'cert-manager.io/v1',
-            kind: 'Certificate',
-            metadata: {
-              name: route.metadata.name + '-cert',
-              namespace: route.metadata.namespace,
-              ownerReferences: [
-                {
-                  apiVersion: route.apiVersion,
-                  kind: route.kind,
-                  controller: true,
-                  name: route.metadata.name,
-                  uid: route.metadata.uid,
-                },
-              ],
-            },
-            spec: baseCertificateSpec {
-              dnsNames: route.spec.hostnames,
-              issuerRef: issuer,
-              secretName: secretName,
-              usages: [
-                'digital signature',
-                'key encipherment',
-              ],
-            },
-          }),
+          ok=function(issuer) ok(
+            if getAnnotation(route, certificatePerHostnameAnnotation) == 'true' then [
+              makeCertificate(route, issuer, secretName, h)
+              for h in std.mapWithIndex(
+                function(index, hostname) {
+                  hostname: hostname,
+                  pos: index,
+                }, route.spec.hostnames
+              )
+            ] else [
+              makeCertificate(route, issuer, secretName),
+            ]
+          ),
         )
     ;
 


### PR DESCRIPTION
This PR introduces a new HTTPRoute annotation (default: `airlock-microgateway.appuio.io/certificate-per-hostname`) which allows users to opt-in to creating one `Certificate` resource per hostname for any given `HTTPRoute` via the HTTPRoute Certificate Manager Espejote ManagedResource. Additionally, the HTTPRoute gateway listener manager Espejote ManagedResource looks at the same annotation in order to figure out whether to configure the per-hostname certificate secret on each hostname's listener.

Notably, this feature is fairly barebones, and explicitly doesn't try to cleanup `Certificate` resources when a HTTPRoute is configured to enable or disable per-hostname certificates. See the docs diff for a more detailed explanation of the limitations.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->