### PR TITLE
Add activeDeadlineSeconds of 15min to upgradejobhook

### DIFF
--- a/component/olm.jsonnet
+++ b/component/olm.jsonnet
@@ -125,6 +125,7 @@ local manual_approval_upgradehook = {
     events: [ 'Start' ],
     template: {
       spec: {
+        activeDeadlineSeconds: 900,
         template: {
           spec: {
             restartPolicy: 'Never',

--- a/tests/golden/olm/airlock-microgateway-operator/airlock-microgateway-operator/01_olm/10_operator_upgradejobhook.yaml
+++ b/tests/golden/olm/airlock-microgateway-operator/airlock-microgateway-operator/01_olm/10_operator_upgradejobhook.yaml
@@ -60,6 +60,7 @@ spec:
       appuio-managed-upgrade: 'true'
   template:
     spec:
+      activeDeadlineSeconds: 900
       template:
         spec:
           containers:


### PR DESCRIPTION
If there's a problem with the upgreadejobhook job (e.g. failed image pull), we want the hook to stop eventually and the upgradejob to fail early. Otherwise the hook will stay in active state until the overall maintenancejob runs into its timeout.

Analogous to https://github.com/appuio/component-openshift-upgrade-controller/pull/106

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
