### PR TITLE
Add `SkipDryRunOnMissingResource=true` ArgoCD annotation in all custom resource helpers

### DIFF
--- a/lib/airlock-microgateway-operator.libsonnet
+++ b/lib/airlock-microgateway-operator.libsonnet
@@ -30,6 +30,9 @@ local GatewayParameters = function(name='') {
   kind: 'GatewayParameters',
   metadata: {
     name: name,
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
   },
 };
 
@@ -44,6 +47,9 @@ local GatewayClass = function(name='') {
   kind: 'GatewayClass',
   metadata: {
     name: name,
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
   },
 };
 
@@ -58,6 +64,9 @@ local Gateway = function(name='') {
   kind: 'Gateway',
   metadata: {
     name: name,
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
   },
 };
 
@@ -72,6 +81,9 @@ local SessionHandling = function(name='') {
   kind: 'SessionHandling',
   metadata: {
     name: name,
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
   },
 };
 
@@ -86,6 +98,9 @@ local RedisProvider = function(name='') {
   kind: 'RedisProvider',
   metadata: {
     name: name,
+    annotations: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
   },
 };
 

--- a/tests/golden/olm/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_classes.yaml
+++ b/tests/golden/olm/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_classes.yaml
@@ -1,6 +1,8 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: test
 spec:
   controllerName: microgateway.airlock.com/gatewayclass-controller
@@ -13,6 +15,8 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: with-ref
 spec:
   controllerName: microgateway.airlock.com/gatewayclass-controller
@@ -25,6 +29,8 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: with-ref-no-namespace
 spec:
   controllerName: microgateway.airlock.com/gatewayclass-controller

--- a/tests/golden/olm/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_parameters.yaml
+++ b/tests/golden/olm/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_parameters.yaml
@@ -1,6 +1,8 @@
 apiVersion: microgateway.airlock.com/v1alpha1
 kind: GatewayParameters
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: airlock
   namespace: airlock-gateway
 spec:
@@ -23,6 +25,8 @@ spec:
 apiVersion: microgateway.airlock.com/v1alpha1
 kind: GatewayParameters
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: airlock
   namespace: syn-airlock-microgateway
 spec:

--- a/tests/golden/resources/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_classes.yaml
+++ b/tests/golden/resources/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_classes.yaml
@@ -1,6 +1,8 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: airlock-microgateway
 spec:
   controllerName: microgateway.airlock.com/gatewayclass-controller

--- a/tests/golden/resources/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_parameters.yaml
+++ b/tests/golden/resources/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateway_parameters.yaml
@@ -1,6 +1,8 @@
 apiVersion: microgateway.airlock.com/v1alpha1
 kind: GatewayParameters
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: params
   namespace: airlock
 spec:

--- a/tests/golden/resources/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateways.yaml
+++ b/tests/golden/resources/airlock-microgateway-operator/airlock-microgateway-operator/02_resources/01_gateways.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     test: xy
   name: gateway-1
   namespace: airlock


### PR DESCRIPTION
This ensures that the first sync of the component on the cluster succeeds even if the Gateway API or Airlock CRDs aren't present yet.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
